### PR TITLE
Update to .NET 8 - demo works

### DIFF
--- a/DotNetCoreRazor/DotNetCoreRazor.csproj
+++ b/DotNetCoreRazor/DotNetCoreRazor.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
- Updating only the target framework on DotNetCoreRazor from .NET 7.0 to .NET 8.0

**This still uses SystemWebAdapters version 1.2, which was the last stable version we've tested with that works for reading from a shared session.**